### PR TITLE
Fix build issue with some BUCK/clang environments

### DIFF
--- a/ios/RNEventSource/RNEventSource.h
+++ b/ios/RNEventSource/RNEventSource.h
@@ -1,4 +1,8 @@
+#if __has_include(<React/RCTBridgeModule.h>)
+#import <React/RCTBridgeModule.h>
+#else
 #import "RCTBridgeModule.h"
+#endif
 #import "EventSource.h"
 
 @interface RNEventSource : NSObject <RCTBridgeModule> {


### PR DESCRIPTION
Some build environments need to use #import <...> to pull in
the react bridge.  Other projects such as react-native-orientation
do this: https://github.com/yamill/react-native-orientation/blob/master/iOS/RCTOrientation/Orientation.h#L7-L11